### PR TITLE
set en_US.UTF-8 locale

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -9,10 +9,14 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y &&\
     apt-get install --fix-missing -y curl git vim wget build-essential python-dev bzip2 libsm6\
-      nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
+      locales nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*tmp
 
+# set utf8 locale:
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 # We run our docker images with a non-root user as a security precaution.
 # main is our user

--- a/images/python/2.7-mini/Dockerfile
+++ b/images/python/2.7-mini/Dockerfile
@@ -8,10 +8,15 @@ MAINTAINER Andrew Osheroff <andrewosh@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y &&\
-    apt-get install -y curl git vim wget build-essential python-dev ca-certificates bzip2 libsm6\
-      nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
+    apt-get install --fix-missing -y curl git vim wget build-essential python-dev bzip2 libsm6\
+      locales nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*tmp
+
+# set utf8 locale:
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 # We run our docker images with a non-root user as a security precaution.
 # main is our user

--- a/images/python/2.7/Dockerfile
+++ b/images/python/2.7/Dockerfile
@@ -8,10 +8,15 @@ MAINTAINER Andrew Osheroff <andrewosh@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y &&\
-    apt-get install -y curl git vim wget build-essential python-dev ca-certificates bzip2 libsm6\
-      nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
+    apt-get install --fix-missing -y curl git vim wget build-essential python-dev bzip2 libsm6\
+      locales nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*tmp
+
+# set utf8 locale:
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 # We run our docker images with a non-root user as a security precaution.
 # main is our user

--- a/images/python/3.5-mini/Dockerfile
+++ b/images/python/3.5-mini/Dockerfile
@@ -8,10 +8,15 @@ MAINTAINER Andrew Osheroff <andrewosh@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y &&\
-    apt-get install -y curl git vim wget build-essential python-dev ca-certificates bzip2 libsm6\
-      nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
+    apt-get install --fix-missing -y curl git vim wget build-essential python-dev bzip2 libsm6\
+      locales nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*tmp
+
+# set utf8 locale:
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 # We run our docker images with a non-root user as a security precaution.
 # main is our user

--- a/images/python/3.5/Dockerfile
+++ b/images/python/3.5/Dockerfile
@@ -8,10 +8,15 @@ MAINTAINER Andrew Osheroff <andrewosh@gmail.com>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y &&\
-    apt-get install -y curl git vim wget build-essential python-dev ca-certificates bzip2 libsm6\
-      nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
+    apt-get install --fix-missing -y curl git vim wget build-essential python-dev bzip2 libsm6\
+      locales nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
     apt-get clean &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*tmp
+
+# set utf8 locale:
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 # We run our docker images with a non-root user as a security precaution.
 # main is our user


### PR DESCRIPTION
default locale is ASCII-only, where serveral things won't work, such as non-ascii filenames.

Fixes https://github.com/binder-project/binder/issues/75
