### PR TITLE
Make docker images smaller by combining anaconda download/run steps

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -44,8 +44,8 @@ ADD .curlrc $HOME
 USER main
 
 # Install Anaconda and Jupyter
-RUN wget https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda2-4.0.0-Linux-x86_64.sh
-RUN bash Anaconda2-4.0.0-Linux-x86_64.sh -b &&\
+RUN wget https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda2-4.0.0-Linux-x86_64.sh &&\
+    bash Anaconda2-4.0.0-Linux-x86_64.sh -b &&\
     rm Anaconda2-4.0.0-Linux-x86_64.sh
 ENV PATH $HOME/anaconda2/bin:$PATH
 RUN conda create -n python3 python=3.5 anaconda

--- a/images/python/2.7-mini/Dockerfile
+++ b/images/python/2.7-mini/Dockerfile
@@ -36,8 +36,8 @@ ADD start-notebook.sh /home/main/
 USER main
 
 # Install Anaconda and Jupyter
-RUN wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-RUN bash Miniconda-latest-Linux-x86_64.sh -b &&\
+RUN wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh &&\
+    bash Miniconda-latest-Linux-x86_64.sh -b &&\
     rm Miniconda-latest-Linux-x86_64.sh
 ENV PATH $HOME/miniconda2/bin:$PATH
 

--- a/images/python/2.7/Dockerfile
+++ b/images/python/2.7/Dockerfile
@@ -36,8 +36,8 @@ ADD start-notebook.sh /home/main/
 USER main
 
 # Install Anaconda and Jupyter
-RUN wget https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda2-4.0.0-Linux-x86_64.sh
-RUN bash Anaconda2-4.0.0-Linux-x86_64.sh -b &&\
+RUN wget https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda2-4.0.0-Linux-x86_64.sh &&\
+    bash Anaconda2-4.0.0-Linux-x86_64.sh -b &&\
     rm Anaconda2-4.0.0-Linux-x86_64.sh
 ENV PATH $HOME/anaconda2/bin:$PATH
 

--- a/images/python/3.5-mini/Dockerfile
+++ b/images/python/3.5-mini/Dockerfile
@@ -36,8 +36,8 @@ ADD start-notebook.sh /home/main/
 USER main
 
 # Install Anaconda and Jupyter
-RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-RUN bash Miniconda3-latest-Linux-x86_64.sh -b &&\
+RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh &&\
+    bash Miniconda3-latest-Linux-x86_64.sh -b &&\
     rm Miniconda3-latest-Linux-x86_64.sh
 ENV PATH $HOME/miniconda3/bin:$PATH
 

--- a/images/python/3.5/Dockerfile
+++ b/images/python/3.5/Dockerfile
@@ -36,8 +36,8 @@ ADD start-notebook.sh /home/main/
 USER main
 
 # Install Anaconda and Jupyter
-RUN wget https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda3-4.0.0-Linux-x86_64.sh
-RUN bash Anaconda3-4.0.0-Linux-x86_64.sh -b &&\
+RUN wget https://3230d63b5fc54e62148e-c95ac804525aac4b6dba79b00b39d1d3.ssl.cf1.rackcdn.com/Anaconda3-4.0.0-Linux-x86_64.sh &&\
+    bash Anaconda3-4.0.0-Linux-x86_64.sh -b &&\
     rm Anaconda3-4.0.0-Linux-x86_64.sh
 ENV PATH $HOME/anaconda3/bin:$PATH
 


### PR DESCRIPTION
This should save you at least ~400MB download/storage per image.

Ideally, you'd have a single base image that all of the other images were built on top of, that way when downloading the different images they would only download the pieces you need. If you're paying for bandwidth, that could save you a ton given the sizes of these images.
