### PR TITLE
Dist-upgrade

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -9,8 +9,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y &&\
     apt-get install --fix-missing -y curl git vim wget build-essential python-dev bzip2 libsm6\
-      locales nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 &&\
+      locales nodejs-legacy npm python-virtualenv python-pip gcc gfortran libglib2.0-0 python-qt4 libstdc++6 libtinfo-dev &&\
     apt-get clean &&\
+    apt-get dist-upgrade -y &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*tmp
 
 # set utf8 locale:


### PR DESCRIPTION
Update the base docker image to include a `dist-upgrade`. This is required for software that need a more recent version of the c runtime.

With this `strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBC` will return:

```
GLIBCXX_3.4
GLIBCXX_3.4.1
GLIBCXX_3.4.2
GLIBCXX_3.4.3
GLIBCXX_3.4.4
GLIBCXX_3.4.5
GLIBCXX_3.4.6
GLIBCXX_3.4.7
GLIBCXX_3.4.8
GLIBCXX_3.4.9
GLIBCXX_3.4.10
GLIBCXX_3.4.11
GLIBCXX_3.4.12
GLIBCXX_3.4.13
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.16
GLIBCXX_3.4.17
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBC_2.3
GLIBC_2.2.5
GLIBC_2.14
GLIBC_2.4
GLIBC_2.18
GLIBC_2.3.4
GLIBC_2.17
GLIBC_2.3.2
GLIBCXX_DEBUG_MESSAGE_LENGTH
```

Before this patch `GLIBCXX_3.4.21` is missing and many packages require it. 